### PR TITLE
Remove double buffer in S3 reader

### DIFF
--- a/pkg/stream/s3/s3_reader_test.go
+++ b/pkg/stream/s3/s3_reader_test.go
@@ -115,68 +115,17 @@ func TestS3Reader_Read_CallFails_ReturnsError(t *testing.T) {
 	assert.True(t, err != nil)
 }
 
-func TestS3Reader_Read_ShouldBuffer(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockS3Client := NewMockS3API(ctrl)
-	setupS3MockExpects(mockS3Client)
-
-	mockS3Client.EXPECT().GetObjectWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(&s3.GetObjectOutput{
-		Body: ioutil.NopCloser(strings.NewReader(testBodyContent[2:4])),
-	}, nil).Times(1)
-
-	config := newS3ReaderConfig()
-	config.BufferSize = 2
-	s3Reader, _ := newS3ReaderWithConfig(mockS3Client, testBucket, testKey, config)
-
-	//First call will read from s3 since the buffer is empty.
-	//Second call should read from internal buffer
-	//Third call should read from s3 again
-	s3Reader.Read(make([]byte, 1))
-	s3Reader.Read(make([]byte, 1))
-	s3Reader.Read(make([]byte, 1))
-}
-
-func TestS3Reader_Seek_ResetsBuffer(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockS3Client := NewMockS3API(ctrl)
-	setupS3MockExpects(mockS3Client)
-	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
-
-	//Read to fill the buffer
-	s3Reader.Read(make([]byte, 1))
-	assert.True(t, s3Reader.bufferEnd != 0)
-
-	s3Reader.Seek(1, io.SeekCurrent)
-	assert.True(t, s3Reader.bufferEnd == 0)
-}
-
-func TestS3Reader_SeekNoop_DoesNotResetBuffer(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockS3Client := NewMockS3API(ctrl)
-	setupS3MockExpects(mockS3Client)
-	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
-
-	//Read to fill the buffer
-	s3Reader.Read(make([]byte, 1))
-	assert.True(t, s3Reader.bufferEnd != 0)
-
-	s3Reader.Seek(0, io.SeekCurrent)
-	assert.True(t, s3Reader.bufferEnd != 0)
-}
-
 func TestS3Reader_Seek_SeeksToCorrectPosition(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockS3Client := NewMockS3API(ctrl)
+
 	mockS3Client.EXPECT().HeadObject(gomock.Any()).Return(&s3.HeadObjectOutput{
 		ContentLength: aws.Int64(int64(len(testBodyContent))),
 		ETag:          aws.String(testEtag),
 	}, nil).Times(1)
-	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
 
+	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
 	s3Reader.Seek(5, io.SeekCurrent)
 	assert.True(t, s3Reader.offset == 5)
 
@@ -191,4 +140,55 @@ func TestS3Reader_Seek_SeeksToCorrectPosition(t *testing.T) {
 
 	s3Reader.Seek(100000, io.SeekCurrent)
 	assert.True(t, s3Reader.offset == s3Reader.ContentLength)
+}
+
+func TestS3Reader_Read_ShouldKeepS3SocketOpen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockS3Client := NewMockS3API(ctrl)
+	setupS3MockExpects(mockS3Client)
+	config := newS3ReaderConfig()
+	s3Reader, _ := newS3ReaderWithConfig(mockS3Client, testBucket, testKey, config)
+
+	//First call will read from s3 since the buffer is empty.
+	//Second call should reuse the existing s3 socket
+	//Third call should reuse the existing s3 socket
+	s3Reader.Read(make([]byte, 1))
+	s3Reader.Read(make([]byte, 1))
+	s3Reader.Read(make([]byte, 1))
+
+	//After finish reading, socket closed
+	assert.Nil(t, s3Reader.resp)
+}
+
+func TestS3Reader_Seek_S3SocketClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockS3Client := NewMockS3API(ctrl)
+	setupS3MockExpects(mockS3Client)
+	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
+
+	//Read to fill the buffer
+	s3Reader.Read(make([]byte, 1))
+	assert.NotNil(t, s3Reader.resp)
+
+	//seek and s3 socket close
+	s3Reader.Seek(0, io.SeekStart)
+	assert.Nil(t, s3Reader.resp)
+}
+
+func TestS3Reader_SeekNoop_DoesNotCloseSocket(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockS3Client := NewMockS3API(ctrl)
+	setupS3MockExpects(mockS3Client)
+	s3Reader, _ := newS3ReaderBucketAndKey(mockS3Client, testBucket, testKey)
+
+	//Read to fill the buffer
+	s3Reader.Read(make([]byte, 1))
+	assert.NotNil(t, s3Reader.resp)
+
+	//seek and s3 socket still open
+	s3Reader.Seek(1, io.SeekStart)
+	assert.NotNil(t, s3Reader.resp)
 }


### PR DESCRIPTION
#### Description of changes:

The S3 client already buffers reads. We should not maintain our own buffer. We also should not be downloading so much when there are no actual changes.

--------------
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
